### PR TITLE
WIP: Add validation to username

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ The server will be deployed on OpenStack as a Docker image. A simple (command li
 - Allow user to leave a chat in the client app
 - The chat room list in the client is not good (when it refreshes every 2 seconds the user selection is lost). To fix this do not clear the entire list when it is refreshed, but add only new chat rooms to the list on refresh.
 - Prevent users from sending empty messages (@barskern)
-- Prevent users from registering a user with a empty username (@barskern)
+- ~~Prevent users from registering a user with a empty username++~~ (@barskern)
 - Add validation of messages on the server side


### PR DESCRIPTION
Make sure that usernames uphold some basic requirements such as:

- Cannot be empty
- Cannot contain less than 3 characters
- Cannot contain more than 20 characters

When such a requirement is broken a response is sent explaining the error.

Further all leading/trailing whitespace is removed from submitted usernames
before any validation is done.

### TODO

- [ ] Move to websocket package