### PR TITLE
Change to use a variadic function signature

### DIFF
--- a/mdb/database.go
+++ b/mdb/database.go
@@ -71,7 +71,7 @@ func (db *Database) MakeIndexes() {
 }
 
 // Insert inserts one or more objects into the database, creates a temporary copy of the session for better concurrency performance
-func (db *Database) Insert(collection DatabaseCollection, objects []interface{}) error {
+func (db *Database) Insert(collection DatabaseCollection, objects ...interface{}) error {
 	sessionCpy := db.session.Copy()
 	defer sessionCpy.Close()
 

--- a/server/chat.go
+++ b/server/chat.go
@@ -34,7 +34,7 @@ func (s *Server) CreateChatRoom(ws *websocket.Conn, msg *websock.Message) {
 
 	// Add the chat room to the database
 	chat := mdb.NewChat(createChatRoomMsg.Name)
-	if err := s.Db.Insert(mdb.ChatRooms, []interface{}{chat}); err != nil {
+	if err := s.Db.Insert(mdb.ChatRooms, chat); err != nil {
 		websock.SendMessage(ws, websock.Error, "Error creating chat room", websock.String)
 		return
 	}
@@ -279,7 +279,7 @@ func (s *Server) AddMessageToDB(username, chatName string, timestamp int64, encr
 		chatMessage.MessageContent = append(chatMessage.MessageContent, msg)
 	}
 
-	if err := s.Db.Insert(mdb.Messages, []interface{}{chatMessage}); err != nil {
+	if err := s.Db.Insert(mdb.Messages, chatMessage); err != nil {
 		log.Println(err)
 	}
 }

--- a/server/user.go
+++ b/server/user.go
@@ -67,7 +67,7 @@ func (s *Server) RegisterUser(ws *websocket.Conn, msg *websock.Message) {
 
 	// Add new user to database
 	user := mdb.NewUser(regUserMsg.Username, regUserMsg.PublicKey)
-	if err := s.Db.Insert(mdb.Users, []interface{}{user}); err != nil {
+	if err := s.Db.Insert(mdb.Users, user); err != nil {
 		websock.SendMessage(ws, websock.Error, "Error registering user", websock.String)
 		return
 	}


### PR DESCRIPTION
Just some syntactic changes. I could probably have just pushed directly to master, but figured it was cleaner to show the change here.

Changes from `[]interface{}{<object>}` to just `<object>` in function
signatures without removing the possibility to pass multiple objects, which
could then be passed like `<object1>, <object2>, <object3>`.

Ready for merge.