### PR TITLE
Add safe websock send/recv API

### DIFF
--- a/cmd/client/chat_session.go
+++ b/cmd/client/chat_session.go
@@ -114,11 +114,11 @@ func (cs *ChatSession) SendChatMessage(message string) {
 		req.EncryptedContent[user.Username] = encMsg
 	}
 
-	websock.Msg.Send(cs.Socket, &websock.Message{Type: websock.SendChat, Message: req})
+	websock.Send(cs.Socket, &websock.Message{Type: websock.SendChat, Message: req})
 }
 
 // LeaveChat is called when a user decides to leave a chat room. The client sends a message
 // notifying the server that the client has left the chat room.
 func (cs *ChatSession) LeaveChat() {
-	websock.Msg.Send(cs.Socket, &websock.Message{Type: websock.LeaveChat})
+	websock.Send(cs.Socket, &websock.Message{Type: websock.LeaveChat})
 }

--- a/cmd/client/handlers.go
+++ b/cmd/client/handlers.go
@@ -24,7 +24,7 @@ func (c *Client) createUserHandler(server string, username string) {
 		Username:  username,
 		PublicKey: util.MarshalPublic(pubKey)}
 
-	websock.Msg.Send(c.ws, &websock.Message{Type: websock.RegisterUser, Message: regUserMsg})
+	websock.Send(c.ws, &websock.Message{Type: websock.RegisterUser, Message: regUserMsg})
 
 	_, err := c.wsReader.GetNext()
 	if err != nil {
@@ -59,7 +59,7 @@ func (c *Client) loginUserHandler(server string, username string) {
 	}
 
 	// Send log in request to server
-	websock.Msg.Send(c.ws, &websock.Message{Type: websock.LoginUser, Message: username})
+	websock.Send(c.ws, &websock.Message{Type: websock.LoginUser, Message: username})
 
 	// Receive auth challenge from server
 	res, err := c.wsReader.GetNext()
@@ -78,7 +78,7 @@ func (c *Client) loginUserHandler(server string, username string) {
 	log.Println(decKey)
 
 	// Send decrypted auth key to server
-	websock.Msg.Send(c.ws, &websock.Message{Type: websock.AuthChallengeResponse, Message: decKey})
+	websock.Send(c.ws, &websock.Message{Type: websock.AuthChallengeResponse, Message: decKey})
 
 	// Check response from server
 	if res, err = c.wsReader.GetNext(); err != nil {
@@ -100,7 +100,7 @@ func (c *Client) createRoomHandler(name, password string, isHidden bool) {
 		Password: password,
 		IsHidden: isHidden}
 
-	websock.Msg.Send(c.ws, &websock.Message{Type: websock.CreateChatRoom, Message: req})
+	websock.Send(c.ws, &websock.Message{Type: websock.CreateChatRoom, Message: req})
 
 	if _, err := c.wsReader.GetNext(); err != nil {
 		c.gui.ShowDialog(err.Error(), nil)
@@ -109,7 +109,7 @@ func (c *Client) createRoomHandler(name, password string, isHidden bool) {
 
 func (c *Client) getChatRooms() (*websock.GetChatRoomsResponseMessage, error) {
 	// Send request for chat rooms
-	websock.Msg.Send(c.ws, &websock.Message{Type: websock.GetChatRooms})
+	websock.Send(c.ws, &websock.Message{Type: websock.GetChatRooms})
 
 	// Get chat rooms response from server
 	res, err := c.wsReader.GetNext()
@@ -126,7 +126,7 @@ func (c *Client) joinChatHandler(name, password string) {
 		Name:     name,
 		Password: password}
 
-	websock.Msg.Send(c.ws, &websock.Message{Type: websock.JoinChat, Message: req})
+	websock.Send(c.ws, &websock.Message{Type: websock.JoinChat, Message: req})
 
 	if _, err := c.wsReader.GetNext(); err != nil {
 		c.gui.ShowDialog(err.Error(), nil)

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -30,14 +30,14 @@ type WSReader struct {
 func (wr *WSReader) Reader() {
 	for {
 		msg := new(websock.Message)
-		err := websock.Msg.Receive(wr.Ws, msg)
+		err := websock.Receive(wr.Ws, msg)
 		if err != nil {
 			log.Println(err)
 			break
 		}
 
 		if msg.Type == websock.Ping {
-			websock.Msg.Send(wr.Ws, &websock.Message{Type: websock.Pong})
+			websock.Send(wr.Ws, &websock.Message{Type: websock.Pong})
 		} else if msg.Type == websock.Error {
 			wr.c <- Result{Message: nil, Err: errors.New(msg.Message.(string))}
 		} else {

--- a/server/server.go
+++ b/server/server.go
@@ -96,7 +96,7 @@ func (s *Server) NoAuthHandler(ws *websocket.Conn, pongCount *int64) bool {
 	// Listen for messages from unauthenticated clients
 	for {
 		msg := new(websock.Message)
-		if err := websock.Msg.Receive(ws, msg); err != nil {
+		if err := websock.Receive(ws, msg); err != nil {
 			log.Println(err)
 			return false
 		}
@@ -123,7 +123,7 @@ func (s *Server) AuthedHandler(ws *websocket.Conn, pongCount *int64) {
 	// Listen for messages from authenticated clients
 	for {
 		msg := new(websock.Message)
-		if err := websock.Msg.Receive(ws, msg); err != nil {
+		if err := websock.Receive(ws, msg); err != nil {
 			log.Println(err)
 			break
 		}
@@ -162,7 +162,7 @@ func (s *Server) Pinger(ws *websocket.Conn) (*time.Ticker, *int64) {
 				return
 			}
 
-			websock.Msg.Send(ws, &websock.Message{Type: websock.Ping})
+			websock.Send(ws, &websock.Message{Type: websock.Ping})
 			atomic.StoreInt64(&pongCount, 0)
 		}
 	}()

--- a/server/user.go
+++ b/server/user.go
@@ -137,11 +137,11 @@ func (s *Server) RegisterUser(ws *websocket.Conn, msg *websock.RegisterUserMessa
 	// Add new user to database
 	user := mdb.NewUser(msg.Username, msg.PublicKey)
 	if err := s.Db.Insert(mdb.Users, user); err != nil {
-		websock.Msg.Send(ws, &websock.Message{Type: websock.Error, Message: "Error registering user"})
+		websock.Send(ws, &websock.Message{Type: websock.Error, Message: "Error registering user"})
 		return
 	}
 
-	websock.Msg.Send(ws, &websock.Message{Type: websock.OK, Message: "User registered"})
+	websock.Send(ws, &websock.Message{Type: websock.OK, Message: "User registered"})
 }
 
 // LoginUser authenticates a user using a randomly generated authentication token
@@ -152,16 +152,16 @@ func (s *Server) LoginUser(ws *websocket.Conn, username string) bool {
 	// Create new user object
 	newUser, encKey, err := NewUser(s.Db, username)
 	if err != nil {
-		websock.Msg.Send(ws, &websock.Message{Type: websock.Error, Message: "User does not exist"})
+		websock.Send(ws, &websock.Message{Type: websock.Error, Message: "User does not exist"})
 		return false
 	}
 
 	// Send auth challenge
-	websock.Msg.Send(ws, &websock.Message{Type: websock.AuthChallenge, Message: encKey})
+	websock.Send(ws, &websock.Message{Type: websock.AuthChallenge, Message: encKey})
 
 	// Receive auth challenge response
 	res := new(websock.Message)
-	if err := websock.Msg.Receive(ws, res); err != nil {
+	if err := websock.Receive(ws, res); err != nil {
 		log.Println(err)
 		return false
 	}
@@ -170,11 +170,11 @@ func (s *Server) LoginUser(ws *websocket.Conn, username string) bool {
 	if newUser.KeyMatches(res.Message.([]byte)) {
 		log.Printf("Client %s authenticated as user %s\n", ws.Request().RemoteAddr, newUser.Username)
 		s.AddClient(ws, newUser)
-		websock.Msg.Send(ws, &websock.Message{Type: websock.OK, Message: "Logged in"})
+		websock.Send(ws, &websock.Message{Type: websock.OK, Message: "Logged in"})
 		return true
 	}
 
-	websock.Msg.Send(ws, &websock.Message{Type: websock.Error, Message: "Invalid auth key"})
+	websock.Send(ws, &websock.Message{Type: websock.Error, Message: "Invalid auth key"})
 	return false
 }
 

--- a/server/validation.go
+++ b/server/validation.go
@@ -26,22 +26,22 @@ func ValidateRegisterUser(ws *websocket.Conn, msg *websock.RegisterUserMessage) 
 	msg.Username = strings.TrimSpace(msg.Username)
 
 	if len(msg.Username) < 3 {
-		websock.Msg.Send(ws, &websock.Message{Type: websock.Error, Message: "Username must contain at least 3 characters"})
+		websock.Send(ws, &websock.Message{Type: websock.Error, Message: "Username must contain at least 3 characters"})
 		return false
 	} else if len(msg.Username) > 20 {
-		websock.Msg.Send(ws, &websock.Message{Type: websock.Error, Message: "Username cannot contain more than 20 characters"})
+		websock.Send(ws, &websock.Message{Type: websock.Error, Message: "Username cannot contain more than 20 characters"})
 		return false
 	} else if !isAlphaNumeric(msg.Username) {
-		websock.Msg.Send(ws, &websock.Message{Type: websock.Error, Message: "Username can only contain alphanumeric characters"})
+		websock.Send(ws, &websock.Message{Type: websock.Error, Message: "Username can only contain alphanumeric characters"})
 		return false
 	}
 
 	// Check key length
 	if pubKey, err := util.UnmarshalPublic(msg.PublicKey); err != nil {
-		websock.Msg.Send(ws, &websock.Message{Type: websock.Error, Message: "Invalid public key"})
+		websock.Send(ws, &websock.Message{Type: websock.Error, Message: "Invalid public key"})
 		return false
 	} else if pubKey.N.BitLen() != 2048 {
-		websock.Msg.Send(ws, &websock.Message{Type: websock.Error, Message: "Size of public key modulus is not 2048 bits"})
+		websock.Send(ws, &websock.Message{Type: websock.Error, Message: "Size of public key modulus is not 2048 bits"})
 		return false
 	}
 
@@ -52,22 +52,22 @@ func ValidateRegisterUser(ws *websocket.Conn, msg *websock.RegisterUserMessage) 
 // the name of the chat room is validated. If the chat room has a password, this is also validated.
 func ValidateCreateChatRoom(ws *websocket.Conn, msg *websock.CreateChatRoomMessage) bool {
 	if len(msg.Name) < 3 {
-		websock.Msg.Send(ws, &websock.Message{Type: websock.Error, Message: "Chat room name must contain at least 3 characters"})
+		websock.Send(ws, &websock.Message{Type: websock.Error, Message: "Chat room name must contain at least 3 characters"})
 		return false
 	} else if len(msg.Name) > 30 {
-		websock.Msg.Send(ws, &websock.Message{Type: websock.Error, Message: "Chat room name cannot contain more than 30 characters"})
+		websock.Send(ws, &websock.Message{Type: websock.Error, Message: "Chat room name cannot contain more than 30 characters"})
 		return false
 	} else if !isAlphaNumeric(msg.Name) {
-		websock.Msg.Send(ws, &websock.Message{Type: websock.Error, Message: "Chat room name can only contain alphanumeric characters"})
+		websock.Send(ws, &websock.Message{Type: websock.Error, Message: "Chat room name can only contain alphanumeric characters"})
 		return false
 	}
 
 	if len(msg.Password) != 0 {
 		if len(msg.Password) < 6 {
-			websock.Msg.Send(ws, &websock.Message{Type: websock.Error, Message: "Password must contain at least 6 characters"})
+			websock.Send(ws, &websock.Message{Type: websock.Error, Message: "Password must contain at least 6 characters"})
 			return false
 		} else if len(msg.Password) > 60 {
-			websock.Msg.Send(ws, &websock.Message{Type: websock.Error, Message: "Password cannot contain more than 60 characters"})
+			websock.Send(ws, &websock.Message{Type: websock.Error, Message: "Password cannot contain more than 60 characters"})
 			return false
 		}
 	}

--- a/websock/codec.go
+++ b/websock/codec.go
@@ -9,8 +9,22 @@ import (
 	"golang.org/x/net/websocket"
 )
 
-// Msg is the decoder for messages sent over the websocket
-var Msg = websocket.Codec{Marshal: marshalMessage, Unmarshal: unmarshalMessage}
+// codec is the decoder for messages sent over the websocket
+var codec = websocket.Codec{Marshal: marshalMessage, Unmarshal: unmarshalMessage}
+
+// Send sends a message to the connection synchronously
+//
+// NB! This will fail if the given message contains incompatible type and content
+func Send(ws *websocket.Conn, msg *Message) error {
+	return codec.Send(ws, msg)
+}
+
+// Receive fetches a message from the connection synchronously
+//
+// NB! This will fail if the received message contains incompatible type and content
+func Receive(ws *websocket.Conn, msg *Message) error {
+	return codec.Receive(ws, msg)
+}
 
 // Register types for gob encoding/decoding
 func init() {


### PR DESCRIPTION
Previously one could send any type because `websock.Msg.Send` takes a
`interface {}`. However within the `marshalMessage` function the first
assertion makes sure that we have a `*Message`. This commit enable the static
type checker to warn us if we try to pass a object which is not a `*Message` to
send/recv.